### PR TITLE
支持esm build

### DIFF
--- a/packages/antd-components/package.json
+++ b/packages/antd-components/package.json
@@ -2,6 +2,7 @@
   "name": "@alist/antd-components",
   "version": "1.0.59-beta.0",
   "main": "lib",
+  "module": "./esm",
   "engines": {
     "npm": ">=3.0.0"
   },

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -2,6 +2,7 @@
   "name": "@alist/antd",
   "version": "1.0.59-beta.0",
   "main": "lib",
+  "module": "./esm",
   "engines": {
     "npm": ">=3.0.0"
   },


### PR DESCRIPTION
package.json 增加module字段用于支持esm构建

antd构建后使用的是es
alist使用 antd/lib

导致配置不能共享